### PR TITLE
make use of node erbium for the docker base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:erbium-alpine
+FROM node:erbium-slim
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:erbium-slim
+FROM node:erbium
 
 WORKDIR /app
 

--- a/config/mediator.json
+++ b/config/mediator.json
@@ -1,6 +1,6 @@
 {
   "urn": "urn:mediator:shell-script",
-  "version": "1.1.1",
+  "version": "1.1.3",
   "name": "OpenHIM Shell Script Mediator",
   "description": "OpenHIM Mediator for executing shell scripts",
   "endpoints": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openhim-mediator-shell-script",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "OpenHIM Mediator for executing shell scripts",
   "author": "Jembi Health Systems NPC",
   "homepage": "https://github.com/jembi/openhim-mediator-shell-script",


### PR DESCRIPTION
The base image that was being used does not contain some tools that are needed for runnung the scripts

MOM-641